### PR TITLE
fix!: Update Arg parsing to operate only as a cargo plugin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs, clippy::missing_errors_doc, clippy::missing_panics_doc)]
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, Args};
 
 use cli::*;
 
@@ -11,6 +11,14 @@ mod update_channel;
 mod utils;
 
 #[derive(Parser)]
+#[command(name = "cargo")]
+#[command(bin_name = "cargo")]
+enum CargoCli {
+    Toolchainer(Cli)
+}
+
+
+#[derive(Args)]
 #[command(version, about, long_about = None)]
 #[command(propagate_version = true)]
 struct Cli {
@@ -24,7 +32,7 @@ enum Commands {
 }
 
 fn main() {
-    let cli = Cli::parse();
+    let CargoCli::Toolchainer(cli) = CargoCli::parse();
     match cli.command {
         Commands::Update(args) => update(args),
     }
@@ -36,6 +44,6 @@ mod tests {
     #[test]
     fn verify_cli() {
         use clap::CommandFactory;
-        Cli::command().debug_assert();
+        CargoCli::command().debug_assert();
     }
 }


### PR DESCRIPTION
Fixes #4 

BREAKING CHANGE: The cli surface for the tool can no longer be directly invoked the same way. Directly invoking the tool will still work, as long as a "toolchainer" subcommand as added at the top level.